### PR TITLE
Make entire summaries clickable

### DIFF
--- a/src/footer.pug
+++ b/src/footer.pug
@@ -15,5 +15,5 @@
 		.o-container.c-footer__container
 			small.c-footer__copyright Copyright &copy; 2019 Cameron Messinides
 			a.c-link.c-footer__social-link(href="https://github.com/cmessinides" target="_blank" rel="noreferrer") Github
-			a.c-link.c-footer__social-link(href="https://codepen.io/cmessinides" target="_blank" rel="noreferrer") Codepen
+			a.c-link.c-footer__social-link(href="https://codepen.io/cmessinides" target="_blank" rel="noreferrer") CodePen
 			a.c-link.c-footer__social-link(href="https://linkedin.com/in/cameron-messinides" target="_blank" rel="noreferrer") LinkedIn

--- a/src/home-section.css
+++ b/src/home-section.css
@@ -1,5 +1,5 @@
 .c-home-section {
-	padding: var(--spacing--lg--rem) 0;
+	padding: var(--spacing--lg--rem) 0 var(--spacing--xl--rem);
 	background-color: var(--color--grey-100);
 	border-top: 1px var(--color--grey-200) solid;
 }

--- a/src/project-summary.pug
+++ b/src/project-summary.pug
@@ -5,12 +5,11 @@ mixin projectSummary({ title, description, href, linkType, thumbnailSrc, categor
 	if variants
 		- classes = classes.concat(variants.map(v => `c-summary--${v}`))
 	+summary()(class=classes)
-		if thumbnailSrc
-			+summaryThumbnail(thumbnailSrc)
-		header.c-summary__header
-			+summaryDetails
-				+summaryDetail('Type')= linkType
-				+summaryDetail('Category')= category
 			+summaryLink(href)
+				if thumbnailSrc
+					+summaryThumbnail(thumbnailSrc)
+				+summaryDetails
+					+summaryDetail('Type')= linkType
+					+summaryDetail('Category')= category
 				+summaryHeading(level)= title
 				+summaryDescription= description

--- a/src/summary.css
+++ b/src/summary.css
@@ -1,19 +1,6 @@
-.c-summary {
-	height: 100%;
-	display: flex;
-	flex-direction: column;
-
-	& > :nth-child(n + 2) {
-		margin-top: var(--spacing--md--px)
-	}
-
-	& > :last-chiild {
-		margin-top: auto;
-	}
-
-	&:nth-last-child(2) {
-		margin-bottom: var(--spacing--md--px);
-	}
+.c-summary__link {
+	display: block;
+	border: none;
 }
 
 .c-summary__heading {
@@ -34,6 +21,7 @@
 .c-summary__thumbnail {
 	display: block;
 	max-width: 100%;
+	margin-bottom: var(--spacing--md--px);
 }
 
 .c-summary__details {

--- a/src/writing-summary.pug
+++ b/src/writing-summary.pug
@@ -5,10 +5,9 @@ mixin writingSummary({ title, description, href, publication, date, variants, le
 	if variants
 		- classes = classes.concat(variants.map(v => `c-summary--${v}`))
 	+summary()(class=classes)
-		header.c-summary__header
+		+summaryLink(href)
 			+summaryDetails
 				+summaryDetail('Publication')= publication
 				+summaryDetail('Date')= date
-			+summaryLink(href)
-				+summaryHeading(level)= title
-				+summaryDescription= description
+			+summaryHeading(level)= title
+			+summaryDescription= description


### PR DESCRIPTION
This makes the summaries on the homepage fully clickable (previously, only the title and description were clickable).

This fixes #6.