### PR TITLE
Correct bad formatting in footer

### DIFF
--- a/src/footer.pug
+++ b/src/footer.pug
@@ -14,6 +14,6 @@
 	footer.c-footer__info
 		.o-container.c-footer__container
 			small.c-footer__copyright Copyright &copy; 2019 Cameron Messinides
-			a.c-link.c-footer__social-link(href="https://github.com/cmessinides" target="_blank" rel="noreferrer") Github
+			a.c-link.c-footer__social-link(href="https://github.com/cmessinides" target="_blank" rel="noreferrer") GitHub
 			a.c-link.c-footer__social-link(href="https://codepen.io/cmessinides" target="_blank" rel="noreferrer") CodePen
 			a.c-link.c-footer__social-link(href="https://linkedin.com/in/cameron-messinides" target="_blank" rel="noreferrer") LinkedIn


### PR DESCRIPTION
This PR changes "Github" to "GitHub" in the site footer.